### PR TITLE
Fix version file URL property

### DIFF
--- a/ReleaseFolder/GameData/WildBlueIndustries/0WBIResources/WBIResources.version
+++ b/ReleaseFolder/GameData/WildBlueIndustries/0WBIResources/WBIResources.version
@@ -1,6 +1,6 @@
 {
     "NAME":"WBIResources",
-    "URL":"https://raw.githubusercontent.com/Angel-125/WBIProps/main/ReleaseFolder/GameData/WildBlueIndustries/WBIResources/WBIResources.version",
+    "URL":"https://raw.githubusercontent.com/Angel-125/WBIProps/main/ReleaseFolder/GameData/WildBlueIndustries/0WBIResources/WBIResources.version",
     "DOWNLOAD":"https://github.com/Angel-125/WBIResources/releases",
     "GITHUB":
     {


### PR DESCRIPTION
Hi @Angel-125, the mod folder starts with `0`, which is missing from the version file URL.
Noticed while reviewing KSP-CKAN/NetKAN#10493.
Cheers!