### PR TITLE
Resolve MM patch warnings

### DIFF
--- a/ReleaseFolder/GameData/WildBlueIndustries/0WBIResources/OmniConverterDefinitions/OmniConverters_CRP.cfg
+++ b/ReleaseFolder/GameData/WildBlueIndustries/0WBIResources/OmniConverterDefinitions/OmniConverters_CRP.cfg
@@ -348,7 +348,7 @@ OMNICONVERTER:NEEDS[CommunityResourcePack]
 }
 
 //Uranium Salter
-OMNICONVERTER:NEEDS[CommunityResourcePack]:NEEDS[FarFutureTechnologies]
+OMNICONVERTER:NEEDS[CommunityResourcePack,FarFutureTechnologies]
 {
 	TechRequired = fieldScience
 	ConverterName = Uranium Salter

--- a/ReleaseFolder/GameData/WildBlueIndustries/0WBIResources/OmniConverterDefinitions/OmniConverters_ClassicStock.cfg
+++ b/ReleaseFolder/GameData/WildBlueIndustries/0WBIResources/OmniConverterDefinitions/OmniConverters_ClassicStock.cfg
@@ -1387,7 +1387,7 @@ OMNICONVERTER:NEEDS[ClassicStock]
 }
 
 //Snacks!
-OMNICONVERTER:NEEDS[ClassicStock]:NEEDS[SnacksUtils]
+OMNICONVERTER:NEEDS[ClassicStock,SnacksUtils]
 {
 	templateTags = hab
 	TechRequired = spaceExploration
@@ -1436,7 +1436,7 @@ OMNICONVERTER:NEEDS[ClassicStock]:NEEDS[SnacksUtils]
 }
 
 
-OMNICONVERTER:NEEDS[ClassicStock]:NEEDS[SnacksUtils]
+OMNICONVERTER:NEEDS[ClassicStock,SnacksUtils]
 {
 	templateTags = hab
 	TechRequired = spaceExploration
@@ -1477,7 +1477,7 @@ OMNICONVERTER:NEEDS[ClassicStock]:NEEDS[SnacksUtils]
 	}
 }
 
-OMNICONVERTER:NEEDS[ClassicStock]:NEEDS[SnacksUtils]
+OMNICONVERTER:NEEDS[ClassicStock,SnacksUtils]
 {
 	templateTags = hab
 	TechRequired = spaceExploration
@@ -1518,7 +1518,7 @@ OMNICONVERTER:NEEDS[ClassicStock]:NEEDS[SnacksUtils]
 	}
 }
 
-OMNICONVERTER:NEEDS[ClassicStock]:NEEDS[SnacksUtils]
+OMNICONVERTER:NEEDS[ClassicStock,SnacksUtils]
 {
 	templateTags = hab
 	TechRequired = advExploration
@@ -1559,7 +1559,7 @@ OMNICONVERTER:NEEDS[ClassicStock]:NEEDS[SnacksUtils]
 	}
 }
 
-OMNICONVERTER:NEEDS[ClassicStock]:NEEDS[SnacksUtils]
+OMNICONVERTER:NEEDS[ClassicStock,SnacksUtils]
 {
 	templateTags = hab
 	TechRequired = advExploration
@@ -1625,7 +1625,7 @@ OMNICONVERTER:NEEDS[ClassicStock]:NEEDS[SnacksUtils]
 	}
 }
 
-OMNICONVERTER:NEEDS[ClassicStock]:NEEDS[SnacksFreshAir]
+OMNICONVERTER:NEEDS[ClassicStock,SnacksFreshAir]
 {
 	templateTags = hab
 	TechRequired = spaceExploration
@@ -1672,7 +1672,7 @@ OMNICONVERTER:NEEDS[ClassicStock]:NEEDS[SnacksFreshAir]
 	}
 }
 
-OMNICONVERTER:NEEDS[ClassicStock]:NEEDS[SnacksFreshAir]
+OMNICONVERTER:NEEDS[ClassicStock,SnacksFreshAir]
 {
 	templateTags = hab
 	TechRequired = spaceExploration
@@ -1705,7 +1705,7 @@ OMNICONVERTER:NEEDS[ClassicStock]:NEEDS[SnacksFreshAir]
 	}
 }
 
-OMNICONVERTER:NEEDS[ClassicStock]:NEEDS[SnacksFreshAir]
+OMNICONVERTER:NEEDS[ClassicStock,SnacksFreshAir]
 {
 	templateTags = hab
 	TechRequired = advExploration
@@ -1752,7 +1752,7 @@ OMNICONVERTER:NEEDS[ClassicStock]:NEEDS[SnacksFreshAir]
 	}
 }
 
-OMNICONVERTER:NEEDS[ClassicStock]:NEEDS[SnacksFreshAir]
+OMNICONVERTER:NEEDS[ClassicStock,SnacksFreshAir]
 {
 	templateTags = hab
 	TechRequired = advExploration
@@ -1799,7 +1799,7 @@ OMNICONVERTER:NEEDS[ClassicStock]:NEEDS[SnacksFreshAir]
 	}
 }
 
-OMNICONVERTER:NEEDS[ClassicStock]:NEEDS[SnacksFreshAir]
+OMNICONVERTER:NEEDS[ClassicStock,SnacksFreshAir]
 {
 	templateTags = hab
 	TechRequired = fieldScience
@@ -1846,7 +1846,7 @@ OMNICONVERTER:NEEDS[ClassicStock]:NEEDS[SnacksFreshAir]
 	}
 }
 
-OMNICONVERTER:NEEDS[ClassicStock]:NEEDS[SnacksFreshAir]
+OMNICONVERTER:NEEDS[ClassicStock,SnacksFreshAir]
 {
 	templateTags = hab
 	TechRequired = fieldScience
@@ -1900,7 +1900,7 @@ OMNICONVERTER:NEEDS[ClassicStock]:NEEDS[SnacksFreshAir]
 	}
 }
 
-OMNICONVERTER:NEEDS[ClassicStock]:NEEDS[SnacksUtils]
+OMNICONVERTER:NEEDS[ClassicStock,SnacksUtils]
 {
 	templateTags = hab
 	TechRequired = spaceExploration


### PR DESCRIPTION
Module Manager only pays attention to the first NEEDS[] block, put both needs in there instead of tacking them on sequentially.